### PR TITLE
add missing utf8 pragma, and fixed pod errors

### DIFF
--- a/lib/Acme/CPANAuthors/Danish.pm
+++ b/lib/Acme/CPANAuthors/Danish.pm
@@ -3,6 +3,7 @@ package Acme::CPANAuthors::Danish;
 
 use strict;
 use warnings;
+use utf8;
 
 use Acme::CPANAuthors::Register (
     ABH      => 'Ask Bjørn Hansen',
@@ -12,7 +13,9 @@ use Acme::CPANAuthors::Register (
     MADZ     => 'Michael Anton Dines Zedeler',
 );
 
-=head2 SYNOPSIS
+=encoding utf-8
+
+=head1 SYNOPSIS
 
     use Acme::CPANAuthors;
     use Acme::CPANAuthors::Danish;


### PR DESCRIPTION
I got this report, caused by some other CPANAuthors module(s) with undeclared wide characters -- http://www.cpantesters.org/cpan/report/f3350cfa-ef0b-11e2-90ca-df1f445abc7e
